### PR TITLE
automate opening PRs using Dependabot for GH action version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # Raise pull requests for version updates
+    # against the `dev` branch
+    target-branch: "dev"


### PR DESCRIPTION
this will enable dependabot to open PRs for GH action version updates

cf. https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates

**reasoning**
- automate opening PRs in situations where GH actions can be upgraded i.e. https://github.com/swisstopo/topo-satromo/issues/49

**note**
- becomes effective once it lands in main branch 
> "You must store this file in the .github directory of your repository in the default branch."

c.f. https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#about-the-dependabotyml-file